### PR TITLE
Changed svt_solver to use the CCS strategy for truncating SVDs

### DIFF
--- a/matrix_completion/svt_solver.py
+++ b/matrix_completion/svt_solver.py
@@ -2,8 +2,30 @@ from __future__ import division
 import numpy as np
 import logging
 
+from sklearn.utils.extmath import randomized_svd, svd_flip
+from scipy.sparse.linalg import svds
 
-def svt_solve(A, mask, tau=None, delta=None, epsilon=1e-2, max_iterations=1000):
+def _my_svd(M, k, algorithm):
+    if algorithm == 'randomized':
+        (U, S, V) = randomized_svd(
+            M, n_components=min(k, M.shape[1]-1), n_oversamples=20)
+    elif algorithm == 'arpack':
+        (U, S, V) = svds(M, k=min(k, min(M.shape)-1))
+        S = S[::-1]
+        U, V = svd_flip(U[:, ::-1], V[::-1])
+    else:
+        raise ValueError("unknown algorithm")
+    return (U, S, V)
+
+def svt_solve(
+        A, 
+        mask, 
+        tau=None, 
+        delta=None, 
+        epsilon=1e-2,
+        rel_improvement=-0.01,
+        max_iterations=1000,
+        algorithm='randomized'):
     """
     Solve using iterative singular value thresholding.
 
@@ -29,12 +51,20 @@ def svt_solve(A, mask, tau=None, delta=None, epsilon=1e-2, max_iterations=1000):
     max_iterations: int
         hard limit on maximum number of iterations
 
+    algorithm: str, 'arpack' or 'randomized' (default='randomized')
+        SVD solver to use. Either 'arpack' for the ARPACK wrapper in 
+        SciPy (scipy.sparse.linalg.svds), or 'randomized' for the 
+        randomized algorithm due to Halko (2009).
+
     Returns:
     --------
     X: m x n array
         completed matrix
     """
     logger = logging.getLogger(__name__)
+    if algorithm not in ['randomized', 'arpack']:
+        raise ValueError("unknown algorithm %r" % algorithm)
+    ell = 5
     Y = np.zeros_like(A)
 
     if not tau:
@@ -42,17 +72,26 @@ def svt_solve(A, mask, tau=None, delta=None, epsilon=1e-2, max_iterations=1000):
     if not delta:
         delta = 1.2 * np.prod(A.shape) / np.sum(mask)
 
-    for _ in range(max_iterations):
+    r_previous = 0
 
-        U, S, V = np.linalg.svd(Y, full_matrices=False)
-        S = np.maximum(S - tau, 0)
-
-        X = np.linalg.multi_dot([U, np.diag(S), V])
+    for k in range(max_iterations):
+        if k == 0:
+            X = np.zeros_like(A)
+        else:
+            sk = r_previous + 1
+            (U, S, V) = _my_svd(Y, sk, algorithm)
+            while np.min(S) >= tau:
+                sk = sk + 5
+                (U, S, V) = _my_svd(Y, sk, algorithm)
+            shrink_S = np.maximum(S - tau, 0)
+            r_previous = np.count_nonzero(shrink_S)
+            diag_shrink_S = np.diag(shrink_S)
+            X = np.linalg.multi_dot([U, diag_shrink_S, V])
         Y += delta * mask * (A - X)
 
         recon_error = np.linalg.norm(mask * (X - A)) / np.linalg.norm(mask * A)
-        if _ % 1 == 0:
-            logger.info("Iteration: %i; Rel error: %.4f" % (_ + 1, recon_error))
+        if k % 1 == 0:
+            logger.info("Iteration: %i; Rel error: %.4f" % (k + 1, recon_error))
         if recon_error < epsilon:
             break
 

--- a/matrix_completion/svt_solver.py
+++ b/matrix_completion/svt_solver.py
@@ -25,7 +25,7 @@ def svt_solve(
         epsilon=1e-2,
         rel_improvement=-0.01,
         max_iterations=1000,
-        algorithm='randomized'):
+        algorithm='arpack'):
     """
     Solve using iterative singular value thresholding.
 
@@ -51,7 +51,7 @@ def svt_solve(
     max_iterations: int
         hard limit on maximum number of iterations
 
-    algorithm: str, 'arpack' or 'randomized' (default='randomized')
+    algorithm: str, 'arpack' or 'randomized' (default='arpack')
         SVD solver to use. Either 'arpack' for the ARPACK wrapper in 
         SciPy (scipy.sparse.linalg.svds), or 'randomized' for the 
         randomized algorithm due to Halko (2009).

--- a/matrix_completion/svt_solver.py
+++ b/matrix_completion/svt_solver.py
@@ -64,7 +64,6 @@ def svt_solve(
     logger = logging.getLogger(__name__)
     if algorithm not in ['randomized', 'arpack']:
         raise ValueError("unknown algorithm %r" % algorithm)
-    ell = 5
     Y = np.zeros_like(A)
 
     if not tau:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ numpy==1.15.4
 osqp==0.5.0
 pyparsing==2.3.1
 python-dateutil==2.8.0
+scikit-learn==0.21.2
 scipy==1.2.0
 scs==2.0.2
 six==1.12.0


### PR DESCRIPTION
Hey @tonyduan -- I've updated SVT solver to use the implementation trick described in the [ Cai, Candes, and Shen 2010 ] paper, which uses truncated SVDs. It doesn't give any speedup for the default 200x160 matrix setting in the example, but it's substantially faster for much bigger matrices. Obviously SVT isn't SOTA any more, but it's still nice for comparisons.

Feel free to let me know if you want me to make any edits before merging!